### PR TITLE
Refactor Llama chat session initialization

### DIFF
--- a/src/AIClient/Examples/BasicLlamaExample.cs
+++ b/src/AIClient/Examples/BasicLlamaExample.cs
@@ -30,11 +30,8 @@ internal class BasicLlamaExample
 
         Console.ForegroundColor = ConsoleColor.Yellow;
 
-        IAsyncEnumerable<string> welcomeResponse = chatClient.InitializeChatSession(
+        await chatClient.InitializeChatSession(
             modelName: "DeepSeek-R1-0528-Qwen3-8B-BF16");
-
-        await foreach (string token in welcomeResponse)
-            Console.Write(token);
 
         while (true)
         {

--- a/src/AIServer.Llama/Brokers/ILlamaBroker.cs
+++ b/src/AIServer.Llama/Brokers/ILlamaBroker.cs
@@ -1,10 +1,11 @@
-﻿using AIServer.Llama.Models;
+using AIServer.Llama.Models;
 using LLama.Common;
+using System.Threading.Tasks;
 
 namespace AIServer.Llama.Brokers;
 
 internal interface ILlamaBroker
 {
     IAsyncEnumerable<string> SendPromptAsync(LlamaChatPrompt prompt);
-    void InitializeChatSession(string modelName);
+    ValueTask InitializeChatSession(string modelName, string systemPrompt);
 }

--- a/src/AIServer.Llama/Brokers/LlamaBroker.cs
+++ b/src/AIServer.Llama/Brokers/LlamaBroker.cs
@@ -1,7 +1,8 @@
-﻿using AIServer.Llama.Models;
+using AIServer.Llama.Models;
 using LLama;
 using LLama.Common;
 using LLama.Sampling;
+using System.Threading.Tasks;
 
 namespace AIServer.Llama.Brokers;
 
@@ -14,7 +15,7 @@ internal class LlamaBroker : ILlamaBroker
     public LlamaBroker(LlamaConfiguration config) =>
         this.config = config;
 
-    public void InitializeChatSession(string modelName)
+    public ValueTask InitializeChatSession(string modelName, string prompt)
     {
         inferenceParams = new InferenceParams
         {
@@ -34,6 +35,10 @@ internal class LlamaBroker : ILlamaBroker
             Path.Combine(config.ModelsPath, $"{modelName}.gguf"));
 
         chatSession = CreateSession(llamaContext);
+        chatSession.ChatHistory.Add(
+            new ChatHistory.Message(AuthorRole.System, prompt));
+
+        return ValueTask.CompletedTask;
     }
 
     public IAsyncEnumerable<string> SendPromptAsync(LlamaChatPrompt prompt) =>
@@ -44,8 +49,8 @@ internal class LlamaBroker : ILlamaBroker
         var modelParams = new ModelParams(modelPath)
         {
             GpuLayerCount = -1,
-            ContextSize = 4096,          
-            BatchSize = 128,              
+            ContextSize = 4096,
+            BatchSize = 128,
             UseMemorymap = true,
             UseMemoryLock = false
         };

--- a/src/AIServer.Llama/Foundations/ILlamaService.cs
+++ b/src/AIServer.Llama/Foundations/ILlamaService.cs
@@ -1,8 +1,10 @@
-﻿using AIServer.Llama.Models;
+using AIServer.Llama.Models;
+using System.Threading.Tasks;
 
 namespace AIServer.Llama.Foundations;
+
 public interface ILlamaService
 {
     IAsyncEnumerable<string> SendPromptAsync(ChatPrompt prompt);
-    IAsyncEnumerable<string> InitializeChatSession(string modelName);
+    ValueTask InitializeChatSession(string modelName, string systemPrompt);
 }

--- a/src/AIServer.Llama/Foundations/LlamaService.cs
+++ b/src/AIServer.Llama/Foundations/LlamaService.cs
@@ -1,6 +1,7 @@
-﻿using AIServer.Llama.Brokers;
+using AIServer.Llama.Brokers;
 using AIServer.Llama.Models;
 using LLama.Common;
+using System.Threading.Tasks;
 
 namespace AIServer.Llama.Foundations;
 
@@ -19,19 +20,8 @@ internal class LlamaService : ILlamaService
         return llamaBroker.SendPromptAsync(llamaPrompt);
     }
 
-    public IAsyncEnumerable<string> InitializeChatSession(string modelName)
-    {
-        llamaBroker.InitializeChatSession(modelName);
-
-        var systemPrompt = new LlamaChatPrompt
-        {
-            Message = new ChatHistory.Message(
-                authorRole: AuthorRole.System,
-                content: "You are a concise assistant. keep your answers to user prompts short.")
-        };
-
-        return llamaBroker.SendPromptAsync(systemPrompt);
-    }
+    public async ValueTask InitializeChatSession(string modelName, string systemPrompt) =>
+        await llamaBroker.InitializeChatSession(modelName, systemPrompt);
 
     LlamaChatPrompt MapChatPromptToLlamaChatPrompt(ChatPrompt prompt)
     {
@@ -50,9 +40,9 @@ internal class LlamaService : ILlamaService
     }
 
     AuthorRole MapAuthorFromString(string authorRoleString)
-    { 
+    {
         return authorRoleString switch
-        { 
+        {
             "system" => AuthorRole.System,
             "user" => AuthorRole.User,
             "assistant" => AuthorRole.Assistant,

--- a/src/AIServer.Llama/ILlamaChatClient.cs
+++ b/src/AIServer.Llama/ILlamaChatClient.cs
@@ -1,8 +1,10 @@
-﻿using AIServer.Llama.Models;
+using AIServer.Llama.Models;
+using System.Threading.Tasks;
 
 namespace AIServer.Llama;
+
 public interface ILlamaChatClient
 {
     IAsyncEnumerable<string> SendAsync(string userMessage);
-    IAsyncEnumerable<string> InitializeChatSession(string modelName);
+    ValueTask InitializeChatSession(string modelName);
 }

--- a/src/AIServer.Llama/LlamaChatClient.cs
+++ b/src/AIServer.Llama/LlamaChatClient.cs
@@ -1,17 +1,19 @@
-﻿using AIServer.Llama.Foundations;
+using AIServer.Llama.Foundations;
 using AIServer.Llama.Models;
+using System.Threading.Tasks;
 
 namespace AIServer.Llama;
 
 public sealed class LlamaChatClient : ILlamaChatClient
 {
+    private const string SystemPrompt = "You are a concise assistant. keep your answers to user prompts short.";
     private readonly ILlamaService llamaService;
 
     public LlamaChatClient(ILlamaService llamaService) =>
         this.llamaService = llamaService;
 
-    public IAsyncEnumerable<string> InitializeChatSession(string modelName) =>
-        llamaService.InitializeChatSession(modelName);
+    public async ValueTask InitializeChatSession(string modelName) =>
+        await llamaService.InitializeChatSession(modelName, SystemPrompt);
 
     public IAsyncEnumerable<string> SendAsync(string userMessage)
     {


### PR DESCRIPTION
## Summary
- make chat session initialization async across Llama interfaces
- store fixed system prompt in broker chat history without emitting tokens
- update example to await initialization without streaming tokens

## Testing
- `dotnet build src/AIServer.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d50d015c8324bcca0e017bff0580