### PR TITLE
Improve tool state parsing and avoid duplicate prompts

### DIFF
--- a/src/TehWardy.AI.WebUI/Components/Conversation/Chat.razor.cs
+++ b/src/TehWardy.AI.WebUI/Components/Conversation/Chat.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using TehWardy.AI.WebUI.Foundations;
 using TehWardy.AI.WebUI.Models;
@@ -97,7 +98,10 @@ public partial class Chat : ComponentBase
             }
             else if (token.Thought == "Tool State Update")
             {
-                await OnNewToolStateFromAssistant.InvokeAsync(token.Content);
+                if (TryExtractToolStateJson(token.Content, out string toolStateJson))
+                {
+                    await OnNewToolStateFromAssistant.InvokeAsync(toolStateJson);
+                }
             }
             else
             {
@@ -129,5 +133,112 @@ public partial class Chat : ComponentBase
     {
         if (e.Key == "Enter" && !e.ShiftKey)
             await SendAsync();
+    }
+
+    private static bool TryExtractToolStateJson(string content, out string toolStateJson)
+    {
+        toolStateJson = null;
+
+        if (string.IsNullOrWhiteSpace(content))
+            return false;
+
+        string trimmed = StripCodeFences(content.Trim());
+
+        if (TryNormalizeJson(trimmed, out toolStateJson))
+            return true;
+
+        int startIndex = trimmed.IndexOf('{');
+
+        if (startIndex < 0)
+            return false;
+
+        int depth = 0;
+        bool inString = false;
+        bool escaped = false;
+        int endIndex = -1;
+
+        for (int i = startIndex; i < trimmed.Length; i++)
+        {
+            char current = trimmed[i];
+
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if (current == '\\' && inString)
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (current == '"')
+            {
+                inString = !inString;
+                continue;
+            }
+
+            if (!inString)
+            {
+                if (current == '{')
+                {
+                    depth++;
+                }
+                else if (current == '}')
+                {
+                    depth--;
+
+                    if (depth == 0)
+                    {
+                        endIndex = i;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (endIndex < 0)
+            return false;
+
+        string jsonCandidate = trimmed.Substring(startIndex, endIndex - startIndex + 1);
+
+        return TryNormalizeJson(jsonCandidate, out toolStateJson);
+    }
+
+    private static string StripCodeFences(string content)
+    {
+        if (!content.StartsWith("```"))
+            return content;
+
+        int firstNewline = content.IndexOf('\n');
+
+        if (firstNewline < 0)
+            return content;
+
+        string withoutOpeningFence = content[(firstNewline + 1)..];
+
+        int closingFenceIndex = withoutOpeningFence.LastIndexOf("```", StringComparison.Ordinal);
+
+        if (closingFenceIndex < 0)
+            return withoutOpeningFence.Trim();
+
+        return withoutOpeningFence[..closingFenceIndex].Trim();
+    }
+
+    private static bool TryNormalizeJson(string candidate, out string normalizedJson)
+    {
+        normalizedJson = null;
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(candidate);
+            normalizedJson = JsonSerializer.Serialize(document.RootElement);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }

--- a/src/TehWardy.AI.WebUI/Components/Conversation/Conversation.razor.cs
+++ b/src/TehWardy.AI.WebUI/Components/Conversation/Conversation.razor.cs
@@ -16,6 +16,7 @@ public partial class Conversation : ComponentBase
     protected ToolHost ToolHost { get; set; }
 
     protected ToolState ToolState { get; set; }
+    private string pendingToolStateJson;
 
     protected void HandleNewConversationStart(Guid conversationId) =>
         Nav.NavigateTo($"/Conversation/{conversationId}");
@@ -39,6 +40,31 @@ public partial class Conversation : ComponentBase
             : null;
     }
 
-    protected void HandleNewToolStateFromAssistant(string serializedToolState) =>
+    protected void HandleNewToolStateFromAssistant(string serializedToolState)
+    {
+        if (ToolState is null)
+        {
+            ToolState = new ToolState
+            {
+                ToolName = "ArchitectureDesigner",
+                Title = "Architecture Designer",
+                InstanceId = Guid.NewGuid()
+            };
+
+            pendingToolStateJson = serializedToolState;
+            StateHasChanged();
+            return;
+        }
+
         ToolHost.AssistantToolStateChanged(serializedToolState);
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (pendingToolStateJson is not null && ToolHost is not null)
+        {
+            ToolHost.AssistantToolStateChanged(pendingToolStateJson);
+            pendingToolStateJson = null;
+        }
+    }
 }

--- a/src/TehWardy.AI/Coordinations/AgenticConversationCoordinationService.cs
+++ b/src/TehWardy.AI/Coordinations/AgenticConversationCoordinationService.cs
@@ -73,8 +73,10 @@ internal class AgenticConversationCoordinationService(
             {
                 firstToken = false;
 
+                string trimmedContent = token.Content.TrimStart();
+
                 potentialToolStateUpate = 
-                    token.Content.StartsWith("`") || token.Content.StartsWith("{");
+                    trimmedContent.StartsWith("`") || trimmedContent.StartsWith("{");
             }
 
             if(potentialToolStateUpate)

--- a/src/TehWardy.AI/Orchestrations/AgenticConversationContextOrchestrationService.cs
+++ b/src/TehWardy.AI/Orchestrations/AgenticConversationContextOrchestrationService.cs
@@ -25,7 +25,18 @@ internal class AgenticConversationContextOrchestrationService(
         Conversation conversation = await conversationService
             .RetrieveConversationByIdAsync(prompt.ConversationId);
 
-        conversation.History.Add(new ChatMessage { Role = "user", Message = prompt.Input });
+        ChatMessage lastMessage = conversation.History.Count > 0
+            ? conversation.History[^1]
+            : null;
+
+        if (lastMessage?.Role != "user" || lastMessage.Message != prompt.Input)
+        {
+            conversation.History.Add(new ChatMessage
+            {
+                Role = "user",
+                Message = prompt.Input
+            });
+        }
 
         return new ConversationContext
         {


### PR DESCRIPTION
### Motivation
- Prevent the same user message from being appended twice when resuming a newly-created conversation. 
- Make detection of assistant-emitted tool state tolerant of leading whitespace in streaming output. 
- Robustly extract JSON tool-state blobs from assistant responses that may include code fences or partial streaming tokens. 
- Ensure the UI opens the architecture tool and then applies the parsed tool state into the tool once it is ready. 

### Description
- In `AgenticConversationContextOrchestrationService.RetrieveConversationContextAsync` guard adding the prompt to `conversation.History` by checking the last message so duplicate user entries are not inserted. 
- In `AgenticConversationCoordinationService.InferStreamingAsync` trim leading whitespace on the first streamed token before checking whether it looks like a tool-state payload so detection is tolerant of formatting. 
- In `Chat.razor.cs` add `TryExtractToolStateJson`, `StripCodeFences`, and `TryNormalizeJson` helpers and only forward `Tool State Update` tokens to the UI when a valid JSON tool-state blob can be extracted and normalized. 
- In `Conversation.razor.cs` add `pendingToolStateJson` handling to create/open the `ToolState` when none exists and apply the assistant-provided tool state after the tool component is rendered via `ToolHost.AssistantToolStateChanged`. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e81470d48324af0760898b8ca7d4)